### PR TITLE
Remove sys_info and hard-code the LOOP_LIMIT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mintex"
-version = "0.1.2"
+version = "0.1.3"
 description = "minimal mutex"
 authors = [
   "garypen <garypen@gmail.com>",
@@ -13,7 +13,3 @@ categories = ["concurrency"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-once_cell = "1.15.0"
-sys-info = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mintex"
-version = "0.1.3"
+version = "0.1.2"
 description = "minimal mutex"
 authors = [
   "garypen <garypen@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A drop-in for `std::sync::Mutex` which doesn't do poisoning. The lock will spin 
 
 The main reason for it to exist, is because I know it does not allocate memory during execution and that's a desirable feature for some use cases.
 
+I have run the tests under [miri](https://github.com/rust-lang/miri) and no issues are detected.
+
 [![Crates.io](https://img.shields.io/crates/v/mintex.svg)](https://crates.io/crates/mintex)
 
 [API Docs](https://docs.rs/mintex/latest/mintex)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,8 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::thread;
 
-use once_cell::sync::Lazy;
-
-// Emprically a good number on an M1
-const LOOP_DEFAULT: u64 = 3000;
-static LOOP_LIMIT: Lazy<u64> = Lazy::new(|| {
-    let speed = sys_info::cpu_speed().unwrap_or(LOOP_DEFAULT);
-    speed / 12
-});
+// Empirically a good number on an M1
+const LOOP_LIMIT: usize = 250;
 
 /// Mutex implementation.
 pub struct Mutex<T: ?Sized> {
@@ -73,7 +67,7 @@ impl<T: ?Sized> Mutex<T> {
                     }
                 }
                 Err(_e) => {
-                    if loop_count > *LOOP_LIMIT {
+                    if loop_count > LOOP_LIMIT {
                         loop_count = 0;
                         thread::yield_now();
                     } else {


### PR DESCRIPTION
Unfortunately using `sys_info` results in a memory allocation, which is not desirable. Revert to just using a sensible hard-coded limit of 250.

fixes: #1