### PR TITLE
Make `Mutex::new` const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,9 @@ impl<T: ?Sized + Default> Default for Mutex<T> {
 impl<T> Mutex<T> {
     #[inline]
     /// Create a new Mutex which wraps the provided data.
-    pub fn new(data: T) -> Self {
+    pub const fn new(data: T) -> Self {
         Self {
-            lock: Default::default(),
+            lock: AtomicBool::new(false),
             data: UnsafeCell::new(data),
         }
     }


### PR DESCRIPTION
Use case, in dhat-rs:

```rs
static TRI_GLOBALS: Mutex<Phase<Globals>> = Mutex::new(Phase::Ready);
```

It was reporting:

```
cannot call non-const associated function `mintex::Mutex::<Phase<Globals>>::new` in statics
```